### PR TITLE
Feat/add rigoblock tvl

### DIFF
--- a/projects/rigoblock/abi.json
+++ b/projects/rigoblock/abi.json
@@ -1,0 +1,3 @@
+{
+  "balanceOf": "function balanceOf(address staker) view returns (uint256)"
+}

--- a/projects/rigoblock/index.js
+++ b/projects/rigoblock/index.js
@@ -1,0 +1,88 @@
+const sdk = require('@defillama/sdk')
+const { getAddress, getLogs } = require('../helper/cache/getLogs')
+const ADDRESSES = require('../helper/coreAssets.json')
+const { transformArbitrumAddress, transformOptimismAddress, transformPolygonAddress } = require('../helper/portedTokens')
+const { sumTokens, sumTokens2 } = require('../helper/unwrapLPs')
+
+const E_WHITELIST = '0xB43baD2638696F8bC82247B92bD56B8DF37d89aB'
+const REGISTRY = '0x06767e8090bA5c4Eca89ED00C3A719909D503ED6' // same on all chains
+// start block is the factory deployment block
+const startBlocks = {
+  ethereum: 15817831,
+  arbitrum: 32290603,
+  optimism: 31239365,
+  polygon: 34751673
+}
+
+function chainTvl(chain) {
+  return async (timestamp, ethBlock, chainBlocks, { api }) => {
+    const START_BLOCK = startBlocks[chain]
+    const logs = (
+      await getLogs({
+        api,
+        target: REGISTRY,
+        fromBlock: START_BLOCK,
+        topic: 'Registered(address,address,bytes32,bytes32,bytes32)',
+      })
+    )
+    const whitelistedTokensLogs = (
+      await getLogs({
+        api,
+        target: E_WHITELIST,
+        fromBlock: START_BLOCK,
+        topic: 'Whitelisted(address,bool)'
+      })
+    )
+    const block = api.block
+    const pools = logs.map((i) => getAddress(i.data));
+    const tokens = whitelistedTokensLogs.map((i) => getAddress(i.topics[1]))
+    // we may have duplicates if a token is first whitelisted than removed
+    const uniqueTokens = [...new Set(tokens)]
+
+    let transform = id=>id
+    if (chain === "arbitrum") {
+      transform = await transformArbitrumAddress()
+    } else if (chain === "optimism") {
+      transform = await transformOptimismAddress()
+    } else if (chain === "polygon") {
+      transform = await transformPolygonAddress()
+    }
+
+    let tokensAndOwners = []
+    const balances = {};
+    // we first get native balances
+    const zeroAddress = '0x0000000000000000000000000000000000000000'
+    for (let pool of pools) {
+      tokensAndOwners.push([zeroAddress, pool])
+    }
+    await sumTokens(balances, tokensAndOwners, block, chain, transform)
+
+    // we append the tokens and owners
+    for (let token of uniqueTokens) {
+      for (let pool of pools) {
+        tokensAndOwners.push([token, pool])
+      }
+    }
+
+    // get uni lp token balances
+    await sumTokens2({ api, owners: pools, transformAddress: transform, resolveUniV3: true });
+
+    return await sumTokens2({ api, tokensAndOwners, transformAddress: transform });
+  }
+}
+
+module.exports = {
+  timetravel: false,
+  ethereum: {
+    tvl: chainTvl('ethereum'),
+  },
+  arbitrum: {
+    tvl: chainTvl('arbitrum'),
+  },
+  optimism: {
+    tvl: chainTvl('optimism'),
+  },
+  polygon: {
+    tvl: chainTvl('polygon'),
+  },
+}

--- a/projects/rigoblock/index.js
+++ b/projects/rigoblock/index.js
@@ -1,4 +1,5 @@
 const sdk = require('@defillama/sdk')
+const abi = require('./abi.json')
 const { getAddress, getLogs } = require('../helper/cache/getLogs')
 const ADDRESSES = require('../helper/coreAssets.json')
 const { transformArbitrumAddress, transformOptimismAddress, transformPolygonAddress } = require('../helper/portedTokens')
@@ -6,17 +7,49 @@ const { sumTokens, sumTokens2 } = require('../helper/unwrapLPs')
 
 const E_WHITELIST = '0xB43baD2638696F8bC82247B92bD56B8DF37d89aB'
 const REGISTRY = '0x06767e8090bA5c4Eca89ED00C3A719909D503ED6' // same on all chains
+const GRG_VAULT_ADDRESSES = {
+  ethereum: '0xfbd2588b170Ff776eBb1aBbB58C0fbE3ffFe1931',
+  arbitrum: '0xE86a667F239A2531C9d398E81154ba125030497e',
+  optimism: '0x5932C223186F7856e08A1D7b35ACc2Aa5fC57BfD',
+  polygon: '0xF241De983959A483F376fDC8Ed09DC580BA66109'
+}
+const GRG_TOKEN_ADDRESSES = {
+  ethereum: '0x4FbB350052Bca5417566f188eB2EBCE5b19BC964',
+  arbitrum: '0x7F4638A58C0615037deCc86f1daE60E55fE92874',
+  optimism: '0xEcF46257ed31c329F204Eb43E254C609dee143B3',
+  polygon: '0xBC0BEA8E634ec838a2a45F8A43E7E16Cd2a8BA99'
+}
+
 // start block is the factory deployment block
-const startBlocks = {
+const START_BLOCKS = {
   ethereum: 15817831,
   arbitrum: 32290603,
   optimism: 31239365,
   polygon: 34751673
 }
 
+async function getStakingBalance(balances, pools, block, chain) {
+  const GRG_VAULT = GRG_VAULT_ADDRESSES[chain].toLowerCase()
+  const GRG_TOKEN = GRG_TOKEN_ADDRESSES[chain].toLowerCase()
+
+  // we query the rigoblock pools' own staked GRG balance
+  const { output: stakedBalances } = await sdk.api.abi.multiCall({
+    calls: pools.map((pool) => ({
+      target: GRG_VAULT,
+      params: [pool],
+    })),
+    chain,
+    abi: abi["balanceOf"],
+    block,
+  })
+
+  // we store the staked balances
+  stakedBalances.forEach(({ output }, i) => sdk.util.sumSingleBalance(balances, GRG_TOKEN, output, chain))
+}
+
 function chainTvl(chain) {
   return async (timestamp, ethBlock, chainBlocks, { api }) => {
-    const START_BLOCK = startBlocks[chain]
+    const START_BLOCK = START_BLOCKS[chain]
     const logs = (
       await getLogs({
         api,
@@ -49,13 +82,16 @@ function chainTvl(chain) {
     }
 
     let tokensAndOwners = []
-    const balances = {};
+    const balances = {}
     // we first get native balances
     const zeroAddress = '0x0000000000000000000000000000000000000000'
     for (let pool of pools) {
       tokensAndOwners.push([zeroAddress, pool])
     }
     await sumTokens(balances, tokensAndOwners, block, chain, transform)
+
+    // we add the staked balances of the pools
+    await getStakingBalance(balances, pools, block, chain)
 
     // we append the tokens and owners
     for (let token of uniqueTokens) {
@@ -64,10 +100,10 @@ function chainTvl(chain) {
       }
     }
 
-    // get uni lp token balances
-    await sumTokens2({ api, owners: pools, transformAddress: transform, resolveUniV3: true });
+    // get tokens and uni lp token balances
+    await sumTokens2({ balances, api, owners: pools, tokensAndOwners, transformAddress: transform, resolveUniV3: true });
 
-    return await sumTokens2({ api, tokensAndOwners, transformAddress: transform });
+    return balances
   }
 }
 

--- a/projects/rigoblock/index.js
+++ b/projects/rigoblock/index.js
@@ -109,6 +109,7 @@ function chainTvl(chain) {
 
 module.exports = {
   timetravel: false,
+  misrepresentedTokens: true,
   ethereum: {
     tvl: chainTvl('ethereum'),
   },
@@ -121,4 +122,5 @@ module.exports = {
   polygon: {
     tvl: chainTvl('polygon'),
   },
+  methodology: `Rigoblock TVL on Ethereum, Arbitrum, Optimism and Polygon pulled from onchain data. Includes the smart pools' own GRG staked balances.`,
 }


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Rigoblock

##### Twitter Link:
https://twitter.com/rigoblock

##### List of audit links if any:


##### Website Link:
https://rigoblock.com/

##### Logo (High resolution, will be shown with rounded borders):
https://github.com/RigoBlock/PR/blob/master/new-logos/rb-logo-256x256.png

##### Current TVL:
ethereum: 1.23M
polygon: 145
arbitrum: 10.12k
optimism: 86.13k

total: 1.33 M

##### Treasury Addresses (if the protocol has treasury)
0x5F8607739c2D2d0b57a4292868C368AB1809767a (Governance contract without token balances, same on all chains)

##### Chain:
Ethereum, Arbitrum, Optimism, Polygon

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)
rigoblock


##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)
4927

##### Short Description (to be shown on DefiLlama):
Swap. earn and interact with DeFi through smart pools.

##### Token address and ticker if any:
ethereum: 0x4fbb350052bca5417566f188eb2ebce5b19bc964 GRG
arbitrum: 0x7F4638A58C0615037deCc86f1daE60E55fE92874 GRG
optimism: 0xEcF46257ed31c329F204Eb43E254C609dee143B3 GRG
polygon: 0xBC0BEA8E634ec838a2a45F8A43E7E16Cd2a8BA99 GRG

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Services

##### Oracle used (Chainlink/Band/API3/TWAP or any other that you are using):

##### forkedFrom (Does your project originate from another project):

##### methodology (what is being counted as tvl, how is tvl being calculated):
Onchain Data. Deployed Rigoblock pools are extracted from querying logs in the Rigoblock registry. The token list for each chain is extracted from querying logs in the token whitelist contract. The pools' own GRG staked balances is added to the balances; also in this case the pools' balances are returned by an onchain call.
